### PR TITLE
Add tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,13 @@
+[tox]
+envlist = py27, pypy
+
+[testenv]
+deps = -rrequirements.dev
+commands = py.test {posargs:--cov nefertari nefertari/tests}
+
+[testenv:flake8]
+deps =
+    flake8==2.3.0
+    pep8==1.6.2
+commands =
+    flake8 nefertari


### PR DESCRIPTION
```
$ pip install tox
...
$ tox
...
  py27: commands succeeded
  pypy: commands succeeded
  congratulations :)
```

py26 and py34 are currently failing so I didn't include them in the default `envlist`. Ditto for `flake8`.

Cc: @hpk42, @pfctdayelise