### PR TITLE
Split BaseView._params into query and json params

### DIFF
--- a/nefertari/authentication/views.py
+++ b/nefertari/authentication/views.py
@@ -16,7 +16,8 @@ class TicketAuthenticationView(BaseView):
         """ Register new user by POSTing all required data.
 
         """
-        user, created = self._model_class.create_account(self._params)
+        user, created = self._model_class.create_account(
+            self._json_params)
 
         if not created:
             raise JHTTPConflict('Looks like you already have an account.')
@@ -26,14 +27,15 @@ class TicketAuthenticationView(BaseView):
         return JHTTPOk('Registered', headers=headers)
 
     def login(self, **params):
-        self._params.update(params)
-        next = self._params.get('next', '')
+        self._json_params.update(params)
+        next = self._query_params.get('next', '')
         login_url = self.request.route_url('login')
         if next.startswith(login_url):
             next = ''  # never use the login form itself as next
 
-        unauthorized_url = self._params.get('unauthorized', None)
-        success, user = self._model_class.authenticate_by_password(self._params)
+        unauthorized_url = self._query_params.get('unauthorized', None)
+        success, user = self._model_class.authenticate_by_password(
+            self._json_params)
 
         if success:
             id_field = user.id_field()
@@ -68,7 +70,7 @@ class TokenAuthenticationView(BaseView):
         User's `Authorization` header value is returned in `WWW-Authenticate`
         header.
         """
-        user, created = self._model_class.create_account(self._params)
+        user, created = self._model_class.create_account(self._json_params)
 
         if not created:
             raise JHTTPConflict('Looks like you already have an account.')
@@ -82,9 +84,9 @@ class TokenAuthenticationView(BaseView):
         User's `Authorization` header value is returned in `WWW-Authenticate`
         header.
         """
-        self._params.update(params)
+        self._json_params.update(params)
         success, self.user = self._model_class.authenticate_by_password(
-            self._params)
+            self._json_params)
 
         if success:
             headers = remember(self.request, self.user.username)

--- a/nefertari/authentication/views.py
+++ b/nefertari/authentication/views.py
@@ -53,7 +53,7 @@ class TicketAuthenticationView(BaseView):
             raise JHTTPNotFound('User not found')
 
     def logout(self):
-        next = self._params.get('next')
+        next = self._query_params.get('next')
         headers = forget(self.request)
         if next:
             return JHTTPFound(location=next, headers=headers)

--- a/nefertari/view.py
+++ b/nefertari/view.py
@@ -87,22 +87,38 @@ class BaseView(object):
 
         return params
 
-    def __init__(self, context, request, _params={}):
+    def __init__(self, context, request, _query_params={}, _json_params={}):
+        """ Prepare data to be used across the view and run init methods.
+
+        Each view has these dicts on data:
+          :_query_params: Params from a query string
+          :_json_params: Request JSON data. Is populated only for
+              PUT, PATCH, POST methods
+          :_params: Join of _query_params and _json_params
+
+        On methods tunneling, _json_params contains the same data as
+        _query_params.
+        """
         self.context = context
         self.request = request
-        self._params = dictset(_params or request.params.mixed())
+        self._query_params = dictset(_query_params or request.params.mixed())
+        self._json_params = dictset(_json_params)
 
         ctype = request.content_type
         if request.method in ['POST', 'PUT', 'PATCH']:
             if ctype == 'application/json':
                 try:
-                    self._params.update(request.json)
+                    self._json_params.update(request.json)
                 except simplejson.JSONDecodeError:
                     log.error(
                         "Expecting JSON. Received: '{}'. Request: {} {}".format(
                             request.body, request.method, request.url))
 
-            self._params = BaseView.convert_dotted(self._params)
+            self._json_params = BaseView.convert_dotted(self._json_params)
+            self._query_params = BaseView.convert_dotted(self._query_params)
+
+        self._params = self._query_params.copy()
+        self._params.update(self._json_params)
 
         # dict of the callables {'action':[callable1, callable2..]}
         # as name implies, before calls are executed before the action is called
@@ -135,12 +151,12 @@ class BaseView(object):
             wrappers.set_public_limits(self)
 
     def convert_ids2objects(self):
-        """ Convert object IDs from `self._params` to objects if needed.
+        """ Convert object IDs from `self._json_params` to objects if needed.
 
         Only IDs tbat belong to relationship field of `self._model_class`
         are converted.
         """
-        for field in self._params.keys():
+        for field in self._json_params.keys():
             if not engine.is_relationship_field(field, self._model_class):
                 continue
             model_cls = engine.relationship_cls(field, self._model_class)
@@ -231,26 +247,10 @@ class BaseView(object):
         return self.request.invoke_subrequest(req)
 
     def needs_confirmation(self):
-        return '__confirmation' not in self._params
-
-    def delete_many(self, **kw):
-        if not self._model_class:
-            log.error("%s _model_class in invalid: %s" % (
-                self.__class__.__name__, self._model_class))
-            raise JHTTPBadRequest
-
-        objs = self._model_class.get_collection(**self._params)
-
-        if self.needs_confirmation():
-            return objs
-
-        count = self._model_class.count(objs)
-        self._model_class._delete_many(objs)
-        return JHTTPOk("Deleted %s %s objects" % (
-            count, self._model_class.__name__))
+        return '__confirmation' not in self._query_params
 
     def id2obj(self, name, model, id_field=None, setdefault=None):
-        if name not in self._params:
+        if name not in self._json_params:
             return
 
         if id_field is None:
@@ -268,11 +268,11 @@ class BaseView(object):
                     raise JHTTPBadRequest('id2obj: Object %s not found' % id_)
                 return obj
 
-        ids = self._params[name]
+        ids = self._json_params[name]
         if isinstance(ids, list):
-            self._params[name] = [_get_object(_id) for _id in ids]
+            self._json_params[name] = [_get_object(_id) for _id in ids]
         else:
-            self._params[name] = _get_object(ids)
+            self._json_params[name] = _get_object(ids)
 
 
 def key_error_view(context, request):

--- a/nefertari/wrappers.py
+++ b/nefertari/wrappers.py
@@ -123,6 +123,8 @@ class apply_privacy(object):
         self.request = request
 
     def _filter_fields(self, data):
+        if '_type' not in data:
+            return data
         try:
             model_cls = engine.get_document_cls(data['_type'])
         except ValueError as ex:
@@ -151,6 +153,8 @@ class apply_privacy(object):
 
     def __call__(self, **kwargs):
         result = kwargs['result']
+        if not isinstance(result, dict):
+            return result
         data = result.get('data', result)
 
         if data:
@@ -305,9 +309,9 @@ def set_public_limits(view):
         'public_max_limit', 100))
 
     try:
-        _limit = int(view._params.get('_limit', 20))
-        _page = int(view._params.get('_page', 0))
-        _start = int(view._params.get('_start', 0))
+        _limit = int(view._query_params.get('_limit', 20))
+        _page = int(view._query_params.get('_page', 0))
+        _start = int(view._query_params.get('_start', 0))
 
         view.add_after_call('index', set_total(view.request, total=public_max),
                             pos=0)
@@ -317,4 +321,4 @@ def set_public_limits(view):
 
     _start = _start or _page * _limit
     if _start + _limit > public_max:
-        view._params['_limit'] = max((public_max - _start), 0)
+        view._query_params['_limit'] = max((public_max - _start), 0)

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -173,7 +173,7 @@ class TestBaseView(object):
         request.params.mixed.return_value = {'param2.foo': 'val2'}
         view = BaseView(context={'foo': 'bar'}, request=request)
         assert request.override_renderer == 'string'
-        assert list(sorted(view._params.keys())) == ['param2']
+        assert view._params.keys() == ['param2']
 
     @patch('nefertari.view.BaseView._run_init_actions')
     def test_init_json_error(self, run):
@@ -189,7 +189,7 @@ class TestBaseView(object):
         request.params.mixed.return_value = {'param2.foo': 'val2'}
         view = BaseView(context={'foo': 'bar'}, request=request)
         assert request.override_renderer == 'nefertari_json'
-        assert list(sorted(view._params.keys())) == ['param2']
+        assert view._params.keys() == ['param2']
 
     @patch('nefertari.view.BaseView.setup_default_wrappers')
     @patch('nefertari.view.BaseView.convert_ids2objects')
@@ -211,7 +211,8 @@ class TestBaseView(object):
     @patch('nefertari.view.BaseView._run_init_actions')
     def test_set_public_limits_no_root(self, run, wrap):
         request = Mock(content_type='', method='', accept=[''])
-        view = BaseView(context={}, request=request, _params={'foo': 'bar'})
+        view = BaseView(
+            context={}, request=request, _query_params={'foo': 'bar'})
         view.root_resource = None
         view.set_public_limits()
         assert not wrap.set_public_limits.called
@@ -220,7 +221,8 @@ class TestBaseView(object):
     @patch('nefertari.view.BaseView._run_init_actions')
     def test_set_public_limits_no_auth(self, run, wrap):
         request = Mock(content_type='', method='', accept=[''])
-        view = BaseView(context={}, request=request, _params={'foo': 'bar'})
+        view = BaseView(
+            context={}, request=request, _query_params={'foo': 'bar'})
         view.root_resource = Mock(auth=False)
         view.set_public_limits()
         assert not wrap.set_public_limits.called
@@ -229,7 +231,8 @@ class TestBaseView(object):
     @patch('nefertari.view.BaseView._run_init_actions')
     def test_set_public_limits_user_authenticated(self, run, wrap):
         request = Mock(content_type='', method='', accept=[''], user='foo')
-        view = BaseView(context={}, request=request, _params={'foo': 'bar'})
+        view = BaseView(
+            context={}, request=request, _query_params={'foo': 'bar'})
         view.root_resource = Mock(auth=True)
         view.set_public_limits()
         assert not wrap.set_public_limits.called
@@ -238,7 +241,8 @@ class TestBaseView(object):
     @patch('nefertari.view.BaseView._run_init_actions')
     def test_set_public_limits_applied(self, run, wrap):
         request = Mock(content_type='', method='', accept=[''], user=None)
-        view = BaseView(context={}, request=request, _params={'foo': 'bar'})
+        view = BaseView(
+            context={}, request=request, _query_params={'foo': 'bar'})
         view.root_resource = Mock(auth=True)
         view.set_public_limits()
         wrap.set_public_limits.assert_called_once_with(view)
@@ -248,7 +252,9 @@ class TestBaseView(object):
     @patch('nefertari.view.BaseView._run_init_actions')
     def test_convert_ids2objects_non_relational(self, run, id2obj, eng):
         request = Mock(content_type='', method='', accept=[''], user=None)
-        view = BaseView(context={}, request=request, _params={'foo': 'bar'})
+        view = BaseView(
+            context={}, request=request, _query_params={'foo1': 'bar'},
+            _json_params={'foo': 'bar'})
         view._model_class = 'Model1'
         eng.is_relationship_field.return_value = False
         view.convert_ids2objects()
@@ -260,7 +266,9 @@ class TestBaseView(object):
     @patch('nefertari.view.BaseView._run_init_actions')
     def test_convert_ids2objects_relational(self, run, id2obj, eng):
         request = Mock(content_type='', method='', accept=[''], user=None)
-        view = BaseView(context={}, request=request, _params={'foo': 'bar'})
+        view = BaseView(
+            context={}, request=request, _query_params={'foo1': 'bar'},
+            _json_params={'foo': 'bar'})
         view._model_class = 'Model1'
         eng.is_relationship_field.return_value = True
         view.convert_ids2objects()
@@ -271,21 +279,24 @@ class TestBaseView(object):
     def test_get_debug(self, run):
         request = Mock(content_type='', method='', accept=[''], user=None)
         request.registry.settings = {'super.debug': 'true'}
-        view = BaseView(context={}, request=request, _params={'foo': 'bar'})
+        view = BaseView(
+            context={}, request=request, _query_params={'foo': 'bar'})
         assert view.get_debug(package='super')
 
     @patch('nefertari.view.BaseView._run_init_actions')
     def test_get_debug_no_package(self, run):
         request = Mock(content_type='', method='', accept=[''], user=None)
         request.registry.settings = {'debug': 'false'}
-        view = BaseView(context={}, request=request, _params={'foo': 'bar'})
+        view = BaseView(
+            context={}, request=request, _query_params={'foo': 'bar'})
         assert not view.get_debug()
 
     @patch('nefertari.view.wrappers')
     @patch('nefertari.view.BaseView._run_init_actions')
     def test_setup_default_wrappers_with_auth(self, run, wrap):
         request = Mock(content_type='', method='', accept=[''], user=None)
-        view = BaseView(context={}, request=request, _params={'foo': 'bar'})
+        view = BaseView(
+            context={}, request=request, _query_params={'foo': 'bar'})
         view.root_resource = Mock(auth=True)
         view.setup_default_wrappers()
         assert len(view._after_calls['index']) == 4
@@ -299,7 +310,8 @@ class TestBaseView(object):
     @patch('nefertari.view.BaseView._run_init_actions')
     def test_setup_default_wrappers_no_auth(self, run, wrap):
         request = Mock(content_type='', method='', accept=[''], user=None)
-        view = BaseView(context={}, request=request, _params={'foo': 'bar'})
+        view = BaseView(
+            context={}, request=request, _query_params={'foo': 'bar'})
         view.root_resource = Mock(auth=None)
         view.setup_default_wrappers()
         assert len(view._after_calls['index']) == 3
@@ -345,14 +357,16 @@ class TestBaseView(object):
     @patch('nefertari.view.BaseView._run_init_actions')
     def test_not_allowed_action(self, run):
         request = Mock(content_type='', method='', accept=[''], user=None)
-        view = BaseView(context={}, request=request, _params={'foo': 'bar'})
+        view = BaseView(
+            context={}, request=request, _query_params={'foo': 'bar'})
         with pytest.raises(JHTTPMethodNotAllowed):
             view.not_allowed_action()
 
     @patch('nefertari.view.BaseView._run_init_actions')
     def test_add_before_or_after_before(self, run):
         request = Mock(content_type='', method='', accept=[''], user=None)
-        view = BaseView(context={}, request=request, _params={'foo': 'bar'})
+        view = BaseView(
+            context={}, request=request, _query_params={'foo': 'bar'})
         callable_ = lambda x: x
         view.add_before_or_after_call(
             action='foo', _callable=callable_, pos=None, before=True)
@@ -361,7 +375,8 @@ class TestBaseView(object):
     @patch('nefertari.view.BaseView._run_init_actions')
     def test_add_before_or_after_after(self, run):
         request = Mock(content_type='', method='', accept=[''], user=None)
-        view = BaseView(context={}, request=request, _params={'foo': 'bar'})
+        view = BaseView(
+            context={}, request=request, _query_params={'foo': 'bar'})
         callable_ = lambda x: x
         view.add_before_or_after_call(
             action='foo', _callable=callable_, pos=None, before=False)
@@ -370,7 +385,8 @@ class TestBaseView(object):
     @patch('nefertari.view.BaseView._run_init_actions')
     def test_add_before_or_after_position(self, run):
         request = Mock(content_type='', method='', accept=[''], user=None)
-        view = BaseView(context={}, request=request, _params={'foo': 'bar'})
+        view = BaseView(
+            context={}, request=request, _query_params={'foo': 'bar'})
         callable1 = lambda x: x
         callable2 = lambda x: x + x
         view.add_before_or_after_call(
@@ -386,7 +402,8 @@ class TestBaseView(object):
     @patch('nefertari.view.BaseView._run_init_actions')
     def test_add_before_or_after_not_callable(self, run):
         request = Mock(content_type='', method='', accept=[''], user=None)
-        view = BaseView(context={}, request=request, _params={'foo': 'bar'})
+        view = BaseView(
+            context={}, request=request, _query_params={'foo': 'bar'})
         with pytest.raises(ValueError) as ex:
             view.add_before_or_after_call(
                 action='foo', _callable='asdasd', pos=None,
@@ -400,7 +417,8 @@ class TestBaseView(object):
         request = Mock(
             content_type='', method='', accept=[''], user=None,
             cookies=['1'])
-        view = BaseView(context={}, request=request, _params={'foo': 'bar'})
+        view = BaseView(
+            context={}, request=request, _query_params={'foo': 'bar'})
         view.subrequest(url='http://', params={'par': 'val'}, method='GET')
         req.blank.assert_called_once_with(
             'http://', cookies=['1'], content_type='application/json',
@@ -415,7 +433,8 @@ class TestBaseView(object):
         request = Mock(
             content_type='', method='', accept=[''], user=None,
             cookies=['1'])
-        view = BaseView(context={}, request=request, _params={'foo': 'bar'})
+        view = BaseView(
+            context={}, request=request, _query_params={'foo': 'bar'})
         view.subrequest(url='http://', params={'par': 'val'}, method='POST')
         req.blank.assert_called_once_with(
             'http://', cookies=['1'], content_type='application/json',
@@ -426,44 +445,12 @@ class TestBaseView(object):
     @patch('nefertari.view.BaseView._run_init_actions')
     def test_needs_confirmation(self, run):
         request = Mock(content_type='', method='', accept=[''], user=None)
-        view = BaseView(context={}, request=request, _params={'foo': 'bar'})
-        view._params['__confirmation'] = ''
-        assert not view.needs_confirmation()
-        view._params.pop('__confirmation')
-        assert view.needs_confirmation()
-
-    @patch('nefertari.view.BaseView._run_init_actions')
-    def test_delete_many_no_model_cls(self, run):
-        request = Mock(content_type='', method='', accept=[''], user=None)
-        view = BaseView(context={}, request=request, _params={'foo': 'bar'})
-        assert not view._model_class
-        with pytest.raises(JHTTPBadRequest):
-            view.delete_many()
-
-    @patch('nefertari.view.BaseView._run_init_actions')
-    def test_delete_many_need_confirm(self, run):
-        request = Mock(content_type='', method='', accept=[''], user=None)
-        view = BaseView(context={}, request=request, _params={'foo': 'bar'})
-        view._model_class = Mock()
-        objs = view.delete_many()
-        view._model_class.get_collection.assert_called_once_with(foo='bar')
-        assert not view._model_class.delete_many.called
-        assert objs == view._model_class.get_collection()
-
-    @patch('nefertari.view.BaseView._run_init_actions')
-    def test_delete_many(self, run):
-        request = Mock(content_type='', method='', accept=[''], user=None)
         view = BaseView(
-            context={}, request=request,
-            _params={'foo': 'bar', '__confirmation': ''})
-        view._model_class = Mock(__name__='Fooo')
-        view._model_class.count.return_value = 1234
-        resp = view.delete_many()
-        assert view._model_class.get_collection.called
-        assert view._model_class.count.called
-        view._model_class._delete_many.assert_called_once_with(
-            view._model_class.get_collection())
-        assert resp.message == 'Deleted 1234 Fooo objects'
+            context={}, request=request, _query_params={'foo': 'bar'})
+        view._query_params['__confirmation'] = ''
+        assert not view.needs_confirmation()
+        view._query_params.pop('__confirmation')
+        assert view.needs_confirmation()
 
     @patch('nefertari.view.BaseView._run_init_actions')
     def test_id2obj(self, run):
@@ -471,10 +458,12 @@ class TestBaseView(object):
         model.id_field.return_value = 'idname'
         model.get.return_value = 'foo'
         request = Mock(content_type='', method='', accept=[''], user=None)
-        view = BaseView(context={}, request=request, _params={'foo': 'bar'})
-        view._params['user'] = '1'
+        view = BaseView(
+            context={}, request=request, _json_params={'foo': 'bar'},
+            _query_params={'foo1': 'bar1'})
+        view._json_params['user'] = '1'
         view.id2obj(name='user', model=model)
-        assert view._params['user'] == 'foo'
+        assert view._json_params['user'] == 'foo'
         model.id_field.assert_called_once_with()
         model.get.assert_called_once_with(idname='1')
 
@@ -484,10 +473,12 @@ class TestBaseView(object):
         model.id_field.return_value = 'idname'
         model.get.return_value = 'foo'
         request = Mock(content_type='', method='', accept=[''], user=None)
-        view = BaseView(context={}, request=request, _params={'foo': 'bar'})
-        view._params['user'] = ['1']
+        view = BaseView(
+            context={}, request=request, _json_params={'foo': 'bar'},
+            _query_params={'foo1': 'bar1'})
+        view._json_params['user'] = ['1']
         view.id2obj(name='user', model=model)
-        assert view._params['user'] == ['foo']
+        assert view._json_params['user'] == ['foo']
         model.id_field.assert_called_once_with()
         model.get.assert_called_once_with(idname='1')
 
@@ -495,7 +486,9 @@ class TestBaseView(object):
     def test_id2obj_not_in_params(self, run):
         model = Mock()
         request = Mock(content_type='', method='', accept=[''], user=None)
-        view = BaseView(context={}, request=request, _params={'foo': 'bar'})
+        view = BaseView(
+            context={}, request=request, _json_params={'foo': 'bar'},
+            _query_params={'foo1': 'bar1'})
         view.id2obj(name='asdasdasd', model=model)
         assert not model.id_field.called
         assert not model.get.called
@@ -506,10 +499,12 @@ class TestBaseView(object):
         model.id_field.return_value = 'idname'
         model.get.return_value = None
         request = Mock(content_type='', method='', accept=[''], user=None)
-        view = BaseView(context={}, request=request, _params={'foo': 'bar'})
-        view._params['user'] = '1'
+        view = BaseView(
+            context={}, request=request, _json_params={'foo': 'bar'},
+            _query_params={'foo1': 'bar1'})
+        view._json_params['user'] = '1'
         view.id2obj(name='user', model=model, setdefault=123)
-        assert view._params['user'] == 123
+        assert view._json_params['user'] == 123
         model.id_field.assert_called_once_with()
         model.get.assert_called_once_with(idname='1')
 
@@ -520,10 +515,12 @@ class TestBaseView(object):
         model.id_field.return_value = 'idname'
         model.get.return_value = None
         request = Mock(content_type='', method='', accept=[''], user=None)
-        view = BaseView(context={}, request=request, _params={'foo': 'bar'})
-        view._params['user'] = id_
+        view = BaseView(
+            context={}, request=request, _json_params={'foo': 'bar'},
+            _query_params={'foo1': 'bar1'})
+        view._json_params['user'] = id_
         view.id2obj(name='user', model=model, setdefault=123)
-        assert view._params['user'] == id_
+        assert view._json_params['user'] == id_
         model.id_field.assert_called_once_with()
         assert not model.get.called
 
@@ -533,8 +530,10 @@ class TestBaseView(object):
         model.id_field.return_value = 'idname'
         model.get.return_value = None
         request = Mock(content_type='', method='', accept=[''], user=None)
-        view = BaseView(context={}, request=request, _params={'foo': 'bar'})
-        view._params['user'] = '1'
+        view = BaseView(
+            context={}, request=request, _json_params={'foo': 'bar'},
+            _query_params={'foo1': 'bar1'})
+        view._json_params['user'] = '1'
         with pytest.raises(JHTTPBadRequest) as ex:
             view.id2obj(name='user', model=model)
         assert str(ex.value) == 'id2obj: Object 1 not found'


### PR DESCRIPTION
Also fixes `apply_privacy` wrapper to work correctly with Attribute view and Singletone view.