### PR TITLE
Refresh index cleanup

### DIFF
--- a/nefertari/elasticsearch.py
+++ b/nefertari/elasticsearch.py
@@ -59,7 +59,9 @@ def includeme(config):
 
 def _bulk_body(body, refresh_index=None):
     kwargs = {'body': body}
-    if refresh_index is not None:
+    refresh_provided = refresh_index is not None
+    refresh_enabled = ES.settings.asbool('enable_refresh_query')
+    if refresh_provided and refresh_enabled:
         kwargs['refresh'] = refresh_index
     return ES.api.bulk(**kwargs)
 

--- a/nefertari/scripts/es.py
+++ b/nefertari/scripts/es.py
@@ -55,11 +55,6 @@ class ESCommand(object):
                   'documents that are missing from index are indexed.'),
             action='store_true',
             default=False)
-        parser.add_argument(
-            '--refresh',
-            help='Refresh the index after performing the operation',
-            action='store_true',
-            default=False)
 
         self.options = parser.parse_args()
         if not self.options.config:
@@ -100,9 +95,8 @@ class ESCommand(object):
             documents = to_dicts(query_set)
 
             if self.options.force:
-                es.index(documents, refresh_index=self.options.refresh)
+                es.index(documents)
             else:
-                es.index_missing_documents(
-                    documents, refresh_index=self.options.refresh)
+                es.index_missing_documents(documents)
 
         return 0

--- a/nefertari/view.py
+++ b/nefertari/view.py
@@ -136,6 +136,12 @@ class BaseView(object):
         elif 'text/plain' in request.accept:
             request.override_renderer = 'string'
 
+        if '_refresh_index' in self._query_params:
+            self.refresh_index = self._query_params.asbool(
+                '_refresh_index', pop=True)
+        else:
+            self.refresh_index = None
+
         self._run_init_actions()
 
     def _run_init_actions(self):


### PR DESCRIPTION
Remove --refresh option from es.py
Store refresh_index query string var in views.BaseView
Take into account ES setting when using refresh