### PR TITLE
Fix apply_privacy wrapper

### DIFF
--- a/nefertari/wrappers.py
+++ b/nefertari/wrappers.py
@@ -157,7 +157,7 @@ class apply_privacy(object):
             return result
         data = result.get('data', result)
 
-        if data:
+        if data and isinstance(data, (dict, list)):
             self.is_admin = kwargs.get('is_admin')
             if self.is_admin is None:
                 user = getattr(self.request, 'user', None)

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -217,6 +217,14 @@ class TestWrappers(unittest.TestCase):
         assert filtered == 'foo'
 
     @patch('nefertari.wrappers.engine')
+    def test_apply_privacy_nested_data_not_dict(self, mock_eng):
+        request = Mock(user=Mock())
+        assert wrappers.apply_privacy(request)(
+            result={'data': 'foo'}, is_admin=True) == {'data': 'foo'}
+        assert wrappers.apply_privacy(request)(
+            result={'data': 1}, is_admin=True) == {'data': 1}
+
+    @patch('nefertari.wrappers.engine')
     def test_apply_privacy_item_admin_calculated(self, mock_eng):
         document_cls = Mock(
             _public_fields=['name', 'desc'],


### PR DESCRIPTION
Privacy is now not applied when nested data is not dict or list.
Fixes the issue of applying_privacy on report queries like ?_count.
E.g. when output data looks like {'data': 1}