### PR TITLE
Rework OPTIONS requests handling

### DIFF
--- a/nefertari/__init__.py
+++ b/nefertari/__init__.py
@@ -28,7 +28,3 @@ def includeme(config):
     config.add_request_method(get_resource_map, 'resource_map', reify=True)
 
     config.add_tween('nefertari.tweens.cache_control')
-
-    config.add_route('options', '/*path', request_method='OPTIONS')
-    config.add_view(view='nefertari.utility_views.OptionsView',
-                    route_name='options')

--- a/nefertari/acl.py
+++ b/nefertari/acl.py
@@ -112,5 +112,5 @@ class AuthenticatedReadACL(BaseACL):
     def context_acl(self, obj):
         return [
             (Allow, 'g:admin', ALL_PERMISSIONS),
-            (Allow, Authenticated, 'show'),
+            (Allow, Authenticated, ['show', 'item_options']),
         ]

--- a/nefertari/acl.py
+++ b/nefertari/acl.py
@@ -86,12 +86,15 @@ class GuestACL(BaseACL):
     """
     def __init__(self, request):
         super(GuestACL, self).__init__(request)
-        self.acl = (Allow, Everyone, ['index', 'show'])
+        self.acl = (
+            Allow, Everyone, ['index', 'show', 'collection_options',
+                              'item_options'])
 
     def context_acl(self, obj):
         return [
             (Allow, 'g:admin', ALL_PERMISSIONS),
-            (Allow, Everyone, ['index', 'show']),
+            (Allow, Everyone, ['index', 'show', 'collection_options',
+                               'item_options']),
         ]
 
 
@@ -104,7 +107,7 @@ class AuthenticatedReadACL(BaseACL):
 
     def __init__(self, request):
         super(AuthenticatedReadACL, self).__init__(request)
-        self.acl = (Allow, Authenticated, 'index')
+        self.acl = (Allow, Authenticated, ['index', 'collection_options'])
 
     def context_acl(self, obj):
         return [

--- a/nefertari/resource.py
+++ b/nefertari/resource.py
@@ -5,7 +5,8 @@ log = logging.getLogger(__name__)
 
 
 ACTIONS = ['index', 'show', 'create', 'update',
-           'delete', 'update_many', 'delete_many']
+           'delete', 'update_many', 'delete_many',
+           'replace']
 DEFAULT_ID_NAME = 'id'
 
 
@@ -84,7 +85,8 @@ def add_resource_routes(config, view, member_name, collection_name, **kwargs):
         if route_name not in added_routes:
             config.add_route(
                 route_name, path, factory=_factory,
-                request_method=['GET', 'POST', 'PUT', 'PATCH', 'DELETE'],
+                request_method=['GET', 'POST', 'PUT', 'PATCH', 'DELETE',
+                                'OPTIONS'],
                 **route_kwargs)
             added_routes[route_name] = path
 
@@ -100,10 +102,16 @@ def add_resource_routes(config, view, member_name, collection_name, **kwargs):
         add_route_and_view(
             config, 'index', name_prefix + collection_name, path,
             'GET')
+        add_route_and_view(
+            config, 'collection_options', name_prefix + collection_name, path,
+            'OPTIONS')
 
     add_route_and_view(
         config, 'show', name_prefix + member_name, path + id_name,
         'GET', traverse=_traverse)
+    add_route_and_view(
+        config, 'item_options', name_prefix + member_name, path + id_name,
+        'OPTIONS', traverse=_traverse)
 
     add_route_and_view(
         config, 'replace', name_prefix + member_name, path + id_name,

--- a/nefertari/resource.py
+++ b/nefertari/resource.py
@@ -102,6 +102,7 @@ def add_resource_routes(config, view, member_name, collection_name, **kwargs):
         add_route_and_view(
             config, 'index', name_prefix + collection_name, path,
             'GET')
+
         add_route_and_view(
             config, 'collection_options', name_prefix + collection_name, path,
             'OPTIONS')
@@ -109,6 +110,7 @@ def add_resource_routes(config, view, member_name, collection_name, **kwargs):
     add_route_and_view(
         config, 'show', name_prefix + member_name, path + id_name,
         'GET', traverse=_traverse)
+
     add_route_and_view(
         config, 'item_options', name_prefix + member_name, path + id_name,
         'OPTIONS', traverse=_traverse)

--- a/nefertari/utility_views.py
+++ b/nefertari/utility_views.py
@@ -38,7 +38,7 @@ class OptionsViewMixin(object):
         request = self.request
         response = request.response
 
-        response.headers['Allow'] = ', '.join(methods)
+        response.headers['Allow'] = ', '.join(sorted(methods))
 
         if 'Access-Control-Request-Method' in request.headers:
             response.headers['Access-Control-Allow-Methods'] = \

--- a/nefertari/utility_views.py
+++ b/nefertari/utility_views.py
@@ -1,28 +1,91 @@
-from pyramid.view import view_config
+class OptionsViewMixin(object):
+    """ Mixin that implements default handling of OPTIONS requests.
 
+    Is used with nefertari.view.BaseView. Relies on last view variables
+    and methods.
 
-@view_config(name='options_view', request_method='OPTIONS',
-             route_name='options')
-class OptionsView(object):
-    all_methods = sorted([
-        'GET', 'HEAD', 'POST', 'OPTIONS',
-        'PUT', 'DELETE', 'PATCH', 'TRACE',
-    ])
+    Attributes:
+        :_item_actions: Map of item routes action names to tuple of HTTP
+            methods they handle
+        :_collection_actions: Map of collection routes action names to
+            tuple of HTTP methods they handle
+    """
+    _item_actions = {
+        'show':         ('GET', 'HEAD'),
+        'replace':      ('PUT',),
+        'update':       ('PATCH',),
+        'delete':       ('DELETE',),
+    }
+    _collection_actions = {
+        'index':        ('GET', 'HEAD'),
+        'create':       ('POST',),
+        'update_many':  ('PUT', 'PATCH'),
+        'delete_many':  ('DELETE',),
+    }
 
-    def __init__(self, request):
-        self.request = request
+    def _set_options_headers(self, methods):
+        """ Set proper headers.
 
-    def __call__(self):
+        Sets following headers:
+            Allow
+            Access-Control-Allow-Methods
+            Access-Control-Allow-Headers
+
+        Arguments:
+            :methods: Sequence of HTTP method names that are value for
+                requested URI
+        """
         request = self.request
+        response = request.response
 
-        request.response.headers['Allow'] = ', '.join(self.all_methods)
+        response.headers['Allow'] = ', '.join(methods)
 
         if 'Access-Control-Request-Method' in request.headers:
-            request.response.headers['Access-Control-Allow-Methods'] = \
-                ', '.join(self.all_methods)
+            response.headers['Access-Control-Allow-Methods'] = \
+                ', '.join(methods)
 
         if 'Access-Control-Request-Headers' in request.headers:
-            request.response.headers['Access-Control-Allow-Headers'] = \
+            response.headers['Access-Control-Allow-Headers'] = \
                 'origin, x-requested-with, content-type'
 
-        return request.response
+        return response
+
+    def _get_handled_methods(self, actions_map):
+        """ Get names of HTTP methods that can be used at requested URI.
+
+        Arguments:
+            :actions_map: Map of actions. Must have the same structure as
+                self._item_actions and self._collection_actions
+        """
+        methods = ('OPTIONS',)
+
+        defined_actions = []
+        for action_name in actions_map.keys():
+            view_method = getattr(self, action_name, None)
+            method_exists = view_method is not None
+            method_defined = view_method != self.not_allowed_action
+            if method_exists and method_defined:
+                defined_actions.append(action_name)
+
+        for action in defined_actions:
+            methods += actions_map[action]
+
+        return methods
+
+    def item_options(self, **kwargs):
+        """ Handle collection OPTIONS request.
+
+        Singular route requests are handled a bit differently because
+        singular views may handle POST requests despite being registered
+        as item routes.
+        """
+        actions = self._item_actions.copy()
+        if self._resource.is_singular:
+            actions['create'] = ('POST',)
+        methods = self._get_handled_methods(actions)
+        return self._set_options_headers(methods)
+
+    def collection_options(self, **kwargs):
+        """ Handle collection item OPTIONS request. """
+        methods = self._get_handled_methods(self._collection_actions)
+        return self._set_options_headers(methods)

--- a/nefertari/utility_views.py
+++ b/nefertari/utility_views.py
@@ -42,7 +42,7 @@ class OptionsViewMixin(object):
 
         if 'Access-Control-Request-Method' in request.headers:
             response.headers['Access-Control-Allow-Methods'] = \
-                ', '.join(methods)
+                ', '.join(sorted(methods))
 
         if 'Access-Control-Request-Headers' in request.headers:
             response.headers['Access-Control-Allow-Headers'] = \

--- a/nefertari/view.py
+++ b/nefertari/view.py
@@ -13,6 +13,7 @@ from nefertari.json_httpexceptions import (
 from nefertari.utils import dictset, merge_dicts, str2dict
 from nefertari import wrappers, engine
 from nefertari.resource import ACTIONS
+from nefertari.utility_views import OptionsViewMixin
 
 log = logging.getLogger(__name__)
 
@@ -59,7 +60,7 @@ class ViewMapper(object):
         return view_mapper_wrapper
 
 
-class BaseView(object):
+class BaseView(OptionsViewMixin):
     """Base class for nefertari views.
     """
 

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -66,28 +66,30 @@ class TestACLsUnit(object):
         acl_obj = acl.GuestACL(request='foo')
         assert acl_obj.acl == [
             (Allow, 'g:admin', ALL_PERMISSIONS),
-            (Allow, Everyone, ['index', 'show'])
+            (Allow, Everyone, ['index', 'show', 'collection_options',
+                               'item_options'])
         ]
 
     def test_guestacl_context_acl(self):
         acl_obj = acl.GuestACL(request='foo')
         assert acl_obj.context_acl('asdasd') == [
             (Allow, 'g:admin', ALL_PERMISSIONS),
-            (Allow, Everyone, ['index', 'show']),
+            (Allow, Everyone, ['index', 'show', 'collection_options',
+                               'item_options']),
         ]
 
     def test_authenticatedreadacl_acl(self):
         acl_obj = acl.AuthenticatedReadACL(request='foo')
         assert acl_obj.acl == [
             (Allow, 'g:admin', ALL_PERMISSIONS),
-            (Allow, Authenticated, 'index')
+            (Allow, Authenticated, ['index', 'collection_options'])
         ]
 
     def test_authenticatedreadacl_context_acl(self):
         acl_obj = acl.AuthenticatedReadACL(request='foo')
         assert acl_obj.context_acl('asdasd') == [
             (Allow, 'g:admin', ALL_PERMISSIONS),
-            (Allow, Authenticated, 'show'),
+            (Allow, Authenticated, ['show', 'item_options']),
         ]
 
 

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -217,9 +217,21 @@ class TestResourceRecognition(Test):
         result = self.app.post('/messages').body
         self.assertEqual(result, six.b('create'))
 
+    def test_head_collection(self):
+        response = self.app.head('/messages')
+        self.assertEqual(response.body, six.b(''))
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.headers)
+
     def test_get_member(self):
         result = self.app.get('/messages/1').body
         self.assertEqual(result, six.b('show'))
+
+    def test_head_member(self):
+        response = self.app.head('/messages/1')
+        self.assertEqual(response.body, six.b(''))
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.headers)
 
     def test_put_member(self):
         result = self.app.put('/messages/1').body
@@ -309,20 +321,24 @@ class TestResource(Test):
         )
 
         self.assertEqual(app.put('/grandpas').body, six.b('"update_many"'))
+        self.assertEqual(app.head('/grandpas').body, six.b(''))
+        self.assertEqual(app.options('/grandpas').body, six.b(''))
 
         self.assertEqual(app.delete('/grandpas/1').body, six.b('"delete"'))
+        self.assertEqual(app.head('/grandpas/1').body, six.b(''))
+        self.assertEqual(app.options('/grandpas/1').body, six.b(''))
 
         self.assertEqual(app.put('/thing').body, six.b('"replace"'))
-
         self.assertEqual(app.patch('/thing').body, six.b('"update"'))
-
         self.assertEqual(app.delete('/thing').body, six.b('"delete"'))
+        self.assertEqual(app.head('/thing').body, six.b(''))
+        self.assertEqual(app.options('/thing').body, six.b(''))
 
         self.assertEqual(app.put('/grandpas/1/wife').body, six.b('"replace"'))
-
         self.assertEqual(app.patch('/grandpas/1/wife').body, six.b('"update"'))
-
         self.assertEqual(app.delete('/grandpas/1/wife').body, six.b('"delete"'))
+        self.assertEqual(app.head('/grandpas/1/wife').body, six.b(''))
+        self.assertEqual(app.options('/grandpas/1/wife').body, six.b(''))
 
         self.assertEqual(six.b('"show"'), app.get('/grandpas/1').body)
         self.assertEqual(six.b('"show"'), app.get('/grandpas/1/wife').body)

--- a/tests/test_utility_views.py
+++ b/tests/test_utility_views.py
@@ -1,43 +1,87 @@
 from mock import Mock
 
-from nefertari import utility_views as uviews
+from nefertari.view import BaseView
 
 
-class TestOptionsView(object):
-    header_str = 'DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT, TRACE'
+class DemoView(BaseView):
+    """ BaseView inherits from OptionsViewMixin """
+    def create(self):
+        pass
 
-    def test_call_methods_header(self):
-        response = Mock(headers={})
-        request = Mock(
-            headers={'Access-Control-Request-Method': ''},
-            response=response)
-        resp = uviews.OptionsView(request=request)()
-        assert resp is response
-        assert response.headers == {
-            'Allow': self.header_str,
-            'Access-Control-Allow-Methods': self.header_str,
+    def index(self, **kwargs):
+        pass
+
+    def update(self):
+        pass
+
+    def delete(self):
+        pass
+
+
+class TestOptionsViewMixin(object):
+
+    def _demo_view(self):
+        return DemoView(**{
+            'request': Mock(
+                content_type='application/json',
+                json={}, method='POST', accept=[''],
+                headers={}, response=Mock(headers={})),
+            'context': {'foo': 'bar'},
+            '_query_params': {'foo': 'bar'},
+            '_json_params': {'foo': 'bar'},
+        })
+
+    def test_set_options_headers(self):
+        view = self._demo_view()
+        view.request.headers = {
+            'Access-Control-Request-Method': '',
+            'Access-Control-Request-Headers': '',
+        }
+        view._set_options_headers(['GET', 'POST'])
+        assert view.request.response.headers == {
+            'Access-Control-Allow-Headers': 'origin, x-requested-with, content-type',
+            'Access-Control-Allow-Methods': 'GET, POST',
+            'Allow': 'GET, POST',
         }
 
-    def test_call_headers_header(self):
-        response = Mock(headers={})
-        request = Mock(
-            headers={'Access-Control-Request-Headers': ''},
-            response=response)
-        resp = uviews.OptionsView(request=request)()
-        assert resp is response
-        assert response.headers == {
-            'Allow': self.header_str,
-            'Access-Control-Allow-Headers': (
-                'origin, x-requested-with, content-type'),
-        }
+    def test_get_handled_methods(self):
+        view = self._demo_view()
+        methods = view._get_handled_methods(view._item_actions)
+        assert sorted(methods) == sorted(['DELETE', 'OPTIONS', 'PATCH'])
+        methods = view._get_handled_methods(view._collection_actions)
+        assert sorted(methods) == sorted([
+            'GET', 'HEAD', 'OPTIONS', 'POST'])
 
-    def test_call_no_headers(self):
-        response = Mock(headers={})
-        request = Mock(
-            headers={},
-            response=response)
-        resp = uviews.OptionsView(request=request)()
-        assert resp is response
-        assert response.headers == {
-            'Allow': self.header_str,
-        }
+    def test_item_options_singular(self):
+        view = self._demo_view()
+        expected_actions = view._item_actions.copy()
+        expected_actions['create'] = ('POST',)
+        view._get_handled_methods = Mock(return_value=['GET', 'POST'])
+        view._set_options_headers = Mock(return_value=1)
+        view._resource = Mock(is_singular=True)
+        assert view.item_options() == 1
+        view._get_handled_methods.assert_called_once_with(
+            expected_actions)
+        view._set_options_headers.assert_called_once_with(
+            ['GET', 'POST'])
+
+    def test_item_options_not_singular(self):
+        view = self._demo_view()
+        view._get_handled_methods = Mock(return_value=['GET', 'POST'])
+        view._set_options_headers = Mock(return_value=1)
+        view._resource = Mock(is_singular=False)
+        assert view.item_options() == 1
+        view._get_handled_methods.assert_called_once_with(
+            view._item_actions)
+        view._set_options_headers.assert_called_once_with(
+            ['GET', 'POST'])
+
+    def test_collection_options_not_singular(self):
+        view = self._demo_view()
+        view._get_handled_methods = Mock(return_value=['GET', 'POST'])
+        view._set_options_headers = Mock(return_value=1)
+        assert view.collection_options() == 1
+        view._get_handled_methods.assert_called_once_with(
+            view._collection_actions)
+        view._set_options_headers.assert_called_once_with(
+            ['GET', 'POST'])


### PR DESCRIPTION
OptionsView became a mixin(OptionsViewMixin)  and BaseView now inherits from it.
OptionsViewMixin implements default methods to handle collection and item OPTIONS requests.

Collection and item OPTIONS requests are handled differently and ability to perform OPTIONS request is controlled by ACLs by using new action names.
Added OPTIONS actions names to pre-defined ACLs where `index` or `show` actions were present.
E.g. if ACE defined rule for `index`, then `collection_options` was added to the same rule. Same for `show`.

OPTIONS request response includes the same headers as before except that headers `Allow` and `Access-Control-Request-Method` only contain names of HTTP methods handlers (view methods) for which are defined on a view.

New actions/viewmethods for OPTIONS are:
* collection_options: handles OPTIONS requests to collection routes
* item_options: handles OPTIONS requests to collection ITEM routes

You won't usually use these methods as they are already defined in OptionsViewMixin and inherited by BaseView.

If you need to change behaviour of these methods, override view methods named the same way actions are (collection_options, item_options).