### PR TITLE
Return created/updated object in root of resp body

### DIFF
--- a/nefertari/json_httpexceptions.py
+++ b/nefertari/json_httpexceptions.py
@@ -29,22 +29,25 @@ def add_stack():
 def create_json_response(obj, request=None, log_it=False, show_stack=False,
                          **extra):
     from nefertari.utils import json_dumps
-    body = dict()
+    body = extra.pop('body', None)
     encoder = extra.pop('encoder', None)
-    for attr in BASE_ATTRS:
-        body[attr] = extra.pop(attr, None) or getattr(obj, attr, None)
 
-    extra['timestamp'] = datetime.utcnow()
-    if request:
-        extra['request_url'] = request.url
-        if obj.status_int in [403, 401]:
-            extra['client_addr'] = request.client_addr
-            extra['remote_addr'] = request.remote_addr
+    if body is None:
+        body = dict()
+        for attr in BASE_ATTRS:
+            body[attr] = extra.pop(attr, None) or getattr(obj, attr, None)
 
-    if obj.location:
-        body['id'] = obj.location.split('/')[-1]
+        extra['timestamp'] = datetime.utcnow()
+        if request:
+            extra['request_url'] = request.url
+            if obj.status_int in [403, 401]:
+                extra['client_addr'] = request.client_addr
+                extra['remote_addr'] = request.remote_addr
 
-    body.update(extra)
+        if obj.location:
+            body['id'] = obj.location.split('/')[-1]
+        body.update(extra)
+
     obj.body = six.b(json_dumps(body, encoder=encoder))
     show_stack = log_it or show_stack
     status = obj.status_int
@@ -97,19 +100,16 @@ def httperrors(context, request):
 class JHTTPCreated(http_exc.HTTPCreated):
     def __init__(self, *args, **kwargs):
         resource = kwargs.pop('resource', None)
-        encoder = kwargs.pop('encoder', None)
-        request = kwargs.pop('request', None)
+        resp_kwargs = {
+            'obj': self,
+            'request': kwargs.pop('request', None),
+            'encoder': kwargs.pop('encoder', None),
+            'body': kwargs.pop('body', None),
+            'resource': resource,
+        }
         super(JHTTPCreated, self).__init__(*args, **kwargs)
 
         if resource and 'location' in kwargs:
             resource['self'] = kwargs['location']
 
-        auth = (request and
-                list(request.registry._root_resources.values())[0].auth)
-        if resource and auth:
-            wrapper = apply_privacy(request=request)
-            resource = wrapper(result=resource)
-
-        create_json_response(
-            self, data=resource,
-            encoder=encoder, request=request)
+        create_json_response(**resp_kwargs)

--- a/nefertari/renderers.py
+++ b/nefertari/renderers.py
@@ -82,31 +82,23 @@ class DefaultResponseRendererMixin(object):
             'encoder': enc_class,
         }
 
-    def _get_create_update_kwargs(self, value, system, common_kw):
-        """ Get kwargs common to create/update/replace view handlers.
-
-        Kwargs include: 'resource', 'location'
-        """
+    def _get_create_update_kwargs(self, value, common_kw):
+        """ Get kwargs common to create, update, replace. """
         kw = common_kw.copy()
-        kw['resource'] = value
-        if hasattr(value, 'to_dict'):
-            kw['resource'] = value.to_dict()
-            resource = system['view']._resource
-            id_name = resource.id_name
-            obj_id = getattr(value, value.pk_field())
-            kw['location'] = system['request'].route_url(
-                resource.uid, **{id_name: obj_id})
+        kw['body'] = value
+        if 'self' in value:
+            kw['headers'] = [('Location', value['self'])]
         return kw
 
     def render_create(self, value, system, common_kw):
         """ Render response for view `create` method (collection POST) """
-        kw = self._get_create_update_kwargs(value, system, common_kw)
+        kw = self._get_create_update_kwargs(value, common_kw)
         return JHTTPCreated(**kw)
 
     def render_update(self, value, system, common_kw):
         """ Render response for view `update` method (item PATCH) """
-        kw = self._get_create_update_kwargs(value, system, common_kw)
-        return JHTTPOk("Updated", **kw)
+        kw = self._get_create_update_kwargs(value, common_kw)
+        return JHTTPOk('Updated', **kw)
 
     def render_replace(self, *args, **kwargs):
         """ Render response for view `replace` method (item PUT) """
@@ -114,14 +106,14 @@ class DefaultResponseRendererMixin(object):
 
     def render_delete(self, value, system, common_kw):
         """ Render response for view `delete` method (item DELETE) """
-        return JHTTPOk("Deleted", **common_kw.copy())
+        return JHTTPOk('Deleted', **common_kw.copy())
 
     def render_delete_many(self, value, system, common_kw):
         """ Render response for view `delete_many` method (collection DELETE)
         """
         if isinstance(value, dict):
             return JHTTPOk(extra=value)
-        msg = "Deleted {} {}(s) objects".format(
+        msg = 'Deleted {} {}(s) objects'.format(
             value, system['view'].Model.__name__)
         return JHTTPOk(msg, **common_kw.copy())
 
@@ -129,7 +121,7 @@ class DefaultResponseRendererMixin(object):
         """ Render response for view `update_many` method
         (collection PUT/PATCH)
         """
-        msg = "Updated {} {}(s) objects".format(
+        msg = 'Updated {} {}(s) objects'.format(
             value, system['view'].Model.__name__)
         return JHTTPOk(msg, **common_kw.copy())
 

--- a/nefertari/view.py
+++ b/nefertari/view.py
@@ -237,34 +237,56 @@ class BaseView(OptionsViewMixin):
     def setup_default_wrappers(self):
         """ Setup defaulf wrappers.
 
-        It's important for `add_etag` wrapper be applied before
+        Wrappers are applied when view method does not return instance
+        of Response. In this case nefertari renderers call wrappers and
+        handle response generation.
+
+        Note: It's important for `add_etag` wrapper be applied before
         `apply_privacy` as later may remove response data that
         is used to generate etag
         """
+        # Index
         self._after_calls['index'] = [
             wrappers.wrap_in_dict(self.request),
             wrappers.add_meta(self.request),
-        ]
-        self._after_calls['index'] += [
             wrappers.add_etag(self.request),
         ]
-        if self._auth_enabled:
-            self._after_calls['index'] += [
-                wrappers.apply_privacy(self.request),
-            ]
 
+        # Show
         self._after_calls['show'] = [
             wrappers.wrap_in_dict(self.request),
             wrappers.add_meta(self.request),
         ]
-        if self._auth_enabled:
-            self._after_calls['show'] += [
-                wrappers.apply_privacy(self.request),
-            ]
 
+        # Create
+        self._after_calls['create'] = [
+            wrappers.wrap_in_dict(self.request),
+            wrappers.add_meta(self.request),
+        ]
+
+        # Update
+        self._after_calls['update'] = [
+            wrappers.wrap_in_dict(self.request),
+            wrappers.add_meta(self.request),
+        ]
+
+        # Replace
+        self._after_calls['replace'] = [
+            wrappers.wrap_in_dict(self.request),
+            wrappers.add_meta(self.request),
+        ]
+
+        # Delete Many
         self._after_calls['delete_many'] = [
             wrappers.add_confirmation_url(self.request)
         ]
+
+        # Privacy wrappers
+        if self._auth_enabled:
+            for meth in ('index', 'show', 'create', 'update', 'replace'):
+                self._after_calls[meth] += [
+                    wrappers.apply_privacy(self.request),
+                ]
 
     def __getattr__(self, attr):
         if attr in ACTIONS:

--- a/nefertari/wrappers.py
+++ b/nefertari/wrappers.py
@@ -217,16 +217,26 @@ class add_meta(object):
     def __init__(self, request):
         self.request = request
 
+    def _set_object_self(self, obj):
+        """ Add 'self' key value to :obj: dict. """
+        location = self.request.path_url
+        obj_id = urllib.parse.quote(str(obj['id']))
+        if not location.endswith(obj_id):
+            location += '/{}'.format(obj_id)
+        obj.setdefault('self', location)
+
     def __call__(self, **kwargs):
         result = kwargs['result']
+
+        if 'data' not in result:
+            self._set_object_self(result)
+            return result
 
         try:
             result['count'] = len(result["data"])
             for each in result['data']:
                 try:
-                    each.setdefault('self', "%s/%s" % (
-                        self.request.path_url,
-                        urllib.parse.quote(str(each['id']))))
+                    self._set_object_self(each)
                 except TypeError:
                     pass
         finally:

--- a/tests/test_json_httpexceptions.py
+++ b/tests/test_json_httpexceptions.py
@@ -91,6 +91,19 @@ class TestJSONHTTPExceptionsModule(object):
         mock_stack.assert_called_with()
         assert mock_stack.call_count == 3
 
+    def test_create_json_response_with_body(self):
+        obj = Mock(
+            status_int=401,
+            location='http://example.com/api')
+        obj2 = jsonex.create_json_response(
+            obj, None, encoder=_JSONEncoder,
+            status_code=402, explanation='success',
+            message='foo', title='bar', body={'zoo': 'zoo'})
+        assert obj2.content_type == 'application/json'
+        assert isinstance(obj2.body, six.binary_type)
+        body = json.loads(obj2.body.decode('utf-8'))
+        assert body == {'zoo': 'zoo'}
+
     def test_exception_response(self):
         jsonex.STATUS_MAP[12345] = lambda x: x + 3
         assert jsonex.exception_response(12345, x=1) == 4
@@ -121,40 +134,5 @@ class TestJSONHTTPExceptionsModule(object):
             location='http://example.com/1',
             encoder=1)
         mock_create.assert_called_once_with(
-            resp, data={'foo': 'bar', 'self': 'http://example.com/1'},
-            request=None, encoder=1)
-
-    @patch.object(jsonex, 'apply_privacy')
-    @patch.object(jsonex, 'create_json_response')
-    def test_jhttpcreated_privacy_applied(self, mock_create, mock_priv):
-        wrapper = Mock()
-        mock_priv.return_value = wrapper
-        wrapper.return_value = {'foo': 'bar', 'self': 'http://example.com/1'}
-        request = Mock()
-        request.registry._root_resources = {'foo': Mock(auth=True)}
-        resp = jsonex.JHTTPCreated(
-            resource={'foo': 'bar', 'zoo': 1},
-            location='http://example.com/1',
-            encoder=1,
-            request=request)
-        mock_create.assert_called_once_with(
-            resp, data={'foo': 'bar', 'self': 'http://example.com/1'},
-            request=request, encoder=1)
-        mock_priv.assert_called_once_with(request=request)
-        wrapper.assert_called_once_with(
-            result={'self': 'http://example.com/1', 'foo': 'bar', 'zoo': 1})
-
-    @patch.object(jsonex, 'apply_privacy')
-    @patch.object(jsonex, 'create_json_response')
-    def test_jhttpcreated_auth_disabled(self, mock_create, mock_priv):
-        request = Mock()
-        request.registry._root_resources = {'foo': Mock(auth=False)}
-        resp = jsonex.JHTTPCreated(
-            resource={'foo': 'bar', 'zoo': 1},
-            location='http://example.com/1',
-            encoder=1,
-            request=request)
-        mock_create.assert_called_once_with(
-            resp, data={'foo': 'bar', 'zoo': 1, 'self': 'http://example.com/1'},
-            request=request, encoder=1)
-        assert not mock_priv.called
+            obj=resp, resource={'foo': 'bar', 'self': 'http://example.com/1'},
+            request=None, encoder=1, body=None)

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -160,32 +160,25 @@ class TestDefaultResponseRendererMixin(object):
         system = self._system_mocks()
         system['view']._resource.id_name = 'story_id'
         system['view']._resource.uid = 'user:stories'
-        value = mock.Mock(id=1)
-        value.pk_field.return_value = 'id'
-        value.to_dict.return_value = {'q': 'd'}
+        value = {'id': 1, 'q': 'd', 'self': 'google.com'}
         mixin = renderers.DefaultResponseRendererMixin()
         mixin.render_create(value, system, {'a': 'b'})
-        system['request'].route_url.assert_called_once_with(
-            'user:stories', story_id=1)
         mock_resp.assert_called_once_with(
-            a='b', resource={'q': 'd'},
-            location=system['request'].route_url())
+            a='b', body={'q': 'd', 'self': 'google.com', 'id': 1},
+            headers=[('Location', 'google.com')])
 
     @mock.patch('nefertari.renderers.JHTTPOk')
     def test_render_update(self, mock_resp):
         system = self._system_mocks()
         system['view']._resource.id_name = 'story_id'
         system['view']._resource.uid = 'user:stories'
-        value = mock.Mock(id=1)
-        value.to_dict.return_value = {'foo': 'bar'}
-        value.pk_field.return_value = 'id'
+        value = {'id': 1, 'q': 'd', 'self': 'google.com'}
         mixin = renderers.DefaultResponseRendererMixin()
         mixin.render_update(value, system, {'a': 'b'})
-        system['request'].route_url.assert_called_once_with(
-            'user:stories', story_id=1)
         mock_resp.assert_called_once_with(
-            "Updated", a='b', resource={'foo': 'bar'},
-            location=system['request'].route_url())
+            "Updated", a='b',
+            body={'q': 'd', 'self': 'google.com', 'id': 1},
+            headers=[('Location', 'google.com')])
 
     def test_render_replace(self):
         mixin = renderers.DefaultResponseRendererMixin()

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -381,8 +381,11 @@ class TestBaseView(object):
         view.setup_default_wrappers()
         assert len(view._after_calls['index']) == 4
         assert len(view._after_calls['show']) == 3
+        assert len(view._after_calls['create']) == 3
+        assert len(view._after_calls['update']) == 3
+        assert len(view._after_calls['replace']) == 3
         assert len(view._after_calls['delete_many']) == 1
-        assert wrap.apply_privacy.call_count == 2
+        assert wrap.apply_privacy.call_count == 5
 
     @patch('nefertari.view.wrappers')
     @patch('nefertari.view.BaseView._run_init_actions')

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -85,7 +85,7 @@ class TestWrappers(unittest.TestCase):
             'foo',
             wrappers.obj2dict(request=None)(result='foo'))
 
-    def test_add_meta(self):
+    def test_add_meta_collection(self):
         result = {'data': [{'id': 4}]}
         request = DummyRequest(path='http://example.com', environ={})
         result = wrappers.add_meta(request=request)(result=result)
@@ -99,6 +99,18 @@ class TestWrappers(unittest.TestCase):
         result = wrappers.add_meta(request=request)(result=result)
         assert result['count'] == 1
         assert result['data'][0]['self'] == 'http://example.com/4'
+
+    def test_add_meta_item(self):
+        result = {'id': 4}
+        request = DummyRequest(path='http://example.com', environ={})
+        result = wrappers.add_meta(request=request)(result=result)
+        assert result == {'id': 4, 'self': 'http://example.com/4'}
+
+    def test_add_meta_url_contains_id(self):
+        result = {'id': 4}
+        request = DummyRequest(path='http://example.com/4', environ={})
+        result = wrappers.add_meta(request=request)(result=result)
+        assert result == {'id': 4, 'self': 'http://example.com/4'}
 
     @patch('nefertari.wrappers.urllib')
     def test_add_meta_type_error(self, mock_lib):


### PR DESCRIPTION
* Allow to pass `body` kwarg to any nefertari JSON HTTP response. Body may be any object that can and will be dumped to JSON without any specific actions.
* JHTTPCreated does not control privacy any more when instantiated explicitly. Privacy control of `create` method response is left to target project implementers if they decide to generate responses by hand. This behaviour was present before for all other view method responses.
* Privacy of create/update/replace is not controlled by wrappers connected in `BaseView`.
* Renderers for create/update/replace now return affected object in root of response body.
* Renderers for create/update/replace now set `Location` header to a URI of created/updated object.
* Part of renderers work on create/update/replace is now moved to wrappers: `wrap_in_dict`, `add_meta` (wrapping object in dict and adding `self` field to JSON respectively).
* Response JSON to create/update/replace now contains `self` field which represents uri of created/updated object.
* Fix add_meta wrapper to set `self` of single object properly.