### PR TITLE
Raise Exception instead of ValueError on permissions fail on aggs

### DIFF
--- a/nefertari/polymorphic.py
+++ b/nefertari/polymorphic.py
@@ -205,7 +205,7 @@ class add_url_polymorphic(PolymorphicHelperMixin, wrappers.add_object_url):
         """
         collections = self.get_collections()
         resources = self.get_resources(collections)
-        return {res.view.Model._type: res for res in resources}
+        return {res.view.Model.__name__: res for res in resources}
 
     def _set_object_self(self, obj):
         """ Override to generate urls instead of just concatenating.

--- a/nefertari/view_helpers.py
+++ b/nefertari/view_helpers.py
@@ -191,7 +191,7 @@ class ESAggregator(object):
         if not_allowed_fields:
             err = 'Not enough permissions to aggregate on fields: {}'.format(
                 ','.join(not_allowed_fields))
-            raise ValueError(err)
+            raise Exception(err)
 
     def aggregate(self):
         """ Perform aggregation and return response. """

--- a/nefertari/view_helpers.py
+++ b/nefertari/view_helpers.py
@@ -2,6 +2,7 @@ import six
 
 from nefertari.utils import dictset
 from nefertari import wrappers
+from nefertari.json_httpexceptions import JHTTPForbidden
 
 
 class OptionsViewMixin(object):
@@ -191,7 +192,7 @@ class ESAggregator(object):
         if not_allowed_fields:
             err = 'Not enough permissions to aggregate on fields: {}'.format(
                 ','.join(not_allowed_fields))
-            raise Exception(err)
+            raise JHTTPForbidden(err)
 
     def aggregate(self):
         """ Perform aggregation and return response. """

--- a/tests/test_polymorphic.py
+++ b/tests/test_polymorphic.py
@@ -178,7 +178,7 @@ class TestAddUrlPolymorphicWrapper(object):
     def test_get_models_map(self, mock_coll, mock_res):
         mock_coll.return_value = ['stories', 'users']
         resource1 = Mock()
-        resource1.view.Model = Mock(_type='Story')
+        resource1.view.Model = Mock(__name__='Story')
         mock_res.return_value = [resource1]
         wrapper = polymorphic.add_url_polymorphic(None)
         model_resources = wrapper.get_models_map()

--- a/tests/test_view_helpers.py
+++ b/tests/test_view_helpers.py
@@ -4,6 +4,7 @@ from mock import Mock, patch
 from nefertari.view import BaseView
 from nefertari.utils import dictset
 from nefertari.view_helpers import ESAggregator
+from nefertari.json_httpexceptions import JHTTPForbidden
 
 
 class DemoView(BaseView):
@@ -178,7 +179,7 @@ class TestESAggregator(object):
         wrapper.return_value = {'foo': None, 'bar': None}
         try:
             aggregator.check_aggregations_privacy({'zoo': 2})
-        except Exception:
+        except JHTTPForbidden:
             raise Exception('Unexpected error')
         aggregator.get_aggregations_fields.assert_called_once_with({'zoo': 2})
         mock_privacy.assert_called_once_with(1)
@@ -195,7 +196,7 @@ class TestESAggregator(object):
         wrapper = Mock()
         mock_privacy.return_value = wrapper
         wrapper.return_value = {'bar': None}
-        with pytest.raises(Exception) as ex:
+        with pytest.raises(JHTTPForbidden) as ex:
             aggregator.check_aggregations_privacy({'zoo': 2})
         expected = 'Not enough permissions to aggregate on fields: foo'
         assert expected == str(ex.value)

--- a/tests/test_view_helpers.py
+++ b/tests/test_view_helpers.py
@@ -178,7 +178,7 @@ class TestESAggregator(object):
         wrapper.return_value = {'foo': None, 'bar': None}
         try:
             aggregator.check_aggregations_privacy({'zoo': 2})
-        except ValueError:
+        except Exception:
             raise Exception('Unexpected error')
         aggregator.get_aggregations_fields.assert_called_once_with({'zoo': 2})
         mock_privacy.assert_called_once_with(1)
@@ -195,7 +195,7 @@ class TestESAggregator(object):
         wrapper = Mock()
         mock_privacy.return_value = wrapper
         wrapper.return_value = {'bar': None}
-        with pytest.raises(ValueError) as ex:
+        with pytest.raises(Exception) as ex:
             aggregator.check_aggregations_privacy({'zoo': 2})
         expected = 'Not enough permissions to aggregate on fields: foo'
         assert expected == str(ex.value)


### PR DESCRIPTION
This also contains other minor fix related to polymorphic views