### PR TITLE
Acl refactor

### DIFF
--- a/nefertari/acl.py
+++ b/nefertari/acl.py
@@ -1,134 +1,277 @@
-from pyramid.security import ALL_PERMISSIONS, Allow, Everyone, Authenticated
+from pyramid.security import(
+    ALL_PERMISSIONS,
+    Allow,
+    Everyone,
+    Authenticated,
+    )
 
 
-class SelfParamMixin(object):
-    """ ACL mixin that implements method to translate input key value
-    to a user ID field, when key value equals :param_value:
 
-    Value is only converted if user is logged in and :request.user:
-    is an instance of :__context_class__:, thus for routes that display
-    auth users.
+class Contained(object):
     """
-    param_value = 'self'
-
-    def resolve_self_key(self, key):
-        if key != self.param_value:
-            return key
-        user = getattr(self.request, 'user', None)
-        if not user or not self.__context_class__:
-            return key
-        if not isinstance(user, self.__context_class__):
-            return key
-        obj_id = getattr(user, user.pk_field()) or key
-        return obj_id
-
-
-class BaseACL(SelfParamMixin):
-    """ Base ACL class.
-
-    Grants:
-        * all collection and item access to admins.
+    Contained resource, which can inherit its acl from its parent.
     """
-    __context_class__ = None
 
-    def __init__(self, request):
-        self.__acl__ = [(Allow, 'g:admin', ALL_PERMISSIONS)]
-        self.__context_acl__ = [(Allow, 'g:admin', ALL_PERMISSIONS)]
+    def __init__(self, request, name='', parent=None):
         self.request = request
+        self.__name__ = name
+        self.__parent__ = parent
 
-    @property
-    def acl(self):
-        return self.__acl__
 
-    @acl.setter
-    def acl(self, val):
-        assert(isinstance(val, tuple))
-        self.__acl__.append(val)
+class ItemACL(Contained):
+    """
+    Collection item Resource.
 
-    def context_acl(self, obj):
-        return self.__context_acl__
+    Override ``db_class`` to specify a db class. Only necessary if you need
+     to consult the db object to deterimine a custom acl.
+
+    Override ``custom_acl`` to provide a custom acl per instance. You will
+    most likely want to use the ``db_object`` method in your implementation
+    of this method. If you don't override this method, then the class's
+    ``__acl__`` is used. If the class doesn't define a ``__acl__``, then it
+    inherits its parent acl.
+    """
+    db_class = None
+
+    def __init__(self, request, name, parent):
+        super(ItemACL, self).__init__(request, name, parent)
+        acl = self.custom_acl()
+        if acl is not None:
+            self.__acl__ = acl
+
+    def custom_acl(self):
+        """
+        Returns a custom __acl__ for this instance. Returns None if this
+        instance doesn't need a custom acl.
+        """
+        return None
+
+    def db_key(self, key):
+        """
+        Override this method to transform the db key, e.g. to support
+        ``self`` as a key on user collections.
+        """
+        return key
+
+    def db_object(self):
+        """
+        Get db object corresponding to this resource
+        """
+        if self.db_class == None:
+            raise Exception('No db class is defined')
+        pk_field = self.db_class.pk_field()
+        key = self.db_key(self.__name__)
+        return self.db_class.get(
+            __raise=True,
+            **{pk_field: key}
+            )
+
+
+class ContainerACL(Contained):
+    """
+    Collection resource.
+
+    Define a ``__acl__`` attribute on this class to define the container's
+    permissions, and default child permissions. Inherits its acl from the
+    root, if no acl is set.
+
+    Override ``child_class`` to specify a different class for child resources.
+    This is only necessary if items need to have a different acl from the
+    collection.
+    """
+    child_class = ItemACL
 
     def __getitem__(self, key):
-        assert(self.__context_class__)
-        key = self.resolve_self_key(key)
-
-        pk_field = self.__context_class__.pk_field()
-        obj = self.__context_class__.get(
-            __raise=True, **{pk_field: key})
-        obj.__acl__ = self.context_acl(obj)
-        obj.__parent__ = self
-        obj.__name__ = key
-        return obj
+        return self.child_class(self.request, key, self)
 
 
-class RootACL(object):
-    __acl__ = [
+# class SelfParamMixin(object):
+#     """ ACL mixin that implements method to translate input key value
+#     to a user ID field, when key value equals :param_value:
+
+#     Value is only converted if user is logged in and :request.user:
+#     is an instance of :__context_class__:, thus for routes that display
+#     auth users.
+#     """
+#     param_value = 'self'
+
+#     def resolve_self_key(self, key):
+#         if key != self.param_value:
+#             return key
+#         user = getattr(self.request, 'user', None)
+#         if not user or not self.__context_class__:
+#             return key
+#         if not isinstance(user, self.__context_class__):
+#             return key
+#         obj_id = getattr(user, user.pk_field()) or key
+#         return obj_id
+
+def authenticated_userid(request):
+    """
+    Helper function that can be used in ``db_key`` to support `self`
+    as a collection key.
+    """
+    user = request.user
+    key = user.pk_field()
+    return getattr(user, key)
+
+# class BaseACL(SelfParamMixin):
+#     """ Base ACL class.
+
+#     Grants:
+#         * all collection and item access to admins.
+#     """
+#     __context_class__ = None
+
+#     def __init__(self, request):
+#         self.__acl__ = [(Allow, 'g:admin', ALL_PERMISSIONS)]
+#         self.__context_acl__ = [(Allow, 'g:admin', ALL_PERMISSIONS)]
+#         self.request = request
+
+#     @property
+#     def acl(self):
+#         return self.__acl__
+
+#     @acl.setter
+#     def acl(self, val):
+#         assert(isinstance(val, tuple))
+#         self.__acl__.append(val)
+
+#     def context_acl(self, obj):
+#         return self.__context_acl__
+
+#     def __getitem__(self, key):
+#         assert(self.__context_class__)
+#         key = self.resolve_self_key(key)
+
+#         pk_field = self.__context_class__.pk_field()
+#         obj = self.__context_class__.get(
+#             __raise=True, **{pk_field: key})
+#         obj.__acl__ = self.context_acl(obj)
+#         obj.__parent__ = self
+#         obj.__name__ = key
+#         return obj
+
+
+# class RootACL(object):
+#     __name__ = ''
+#     __parent__ = None
+#     __acl__ = (
+#         (Allow, 'g:admin', ALL_PERMISSIONS),
+#     )
+
+#     def __init__(self, request):
+#         self.request = request
+
+
+class RootACL(Contained):
+    __acl__ = (
         (Allow, 'g:admin', ALL_PERMISSIONS),
-    ]
+    )
 
-    def __init__(self, request):
-        self.request = request
+# class AdminACL(BaseACL):
+#     """ Admin level ACL. Gives all access to all actions.
 
+#     May be used as a default factory for root resource.
+#     """
+#     def __getitem__(self, key):
+#         return 1
 
-class AdminACL(BaseACL):
-    """ Admin level ACL. Gives all access to all actions.
+class AdminACL(ContainerACL):
+    """ Admin level ACL. Gives all access to all actions to admin.
 
     May be used as a default factory for root resource.
     """
-    def __getitem__(self, key):
-        return 1
+
+    # XXX not really sure what the __getitem__ -> 1 business is about,
+    # need to clarify the purpose of this class
+
+    __acl__ = (
+        (Allow, 'g:admin', ALL_PERMISSIONS),
+    )
 
 
-class GuestACL(BaseACL):
+# class GuestACL(BaseACL):
+#     """ Guest level ACL.
+
+#     Gives read permissions to everyone.
+#     """
+#     def __init__(self, request):
+#         super(GuestACL, self).__init__(request)
+#         self.acl = (
+#             Allow, Everyone, ['index', 'show', 'collection_options',
+#                               'item_options'])
+
+#     def context_acl(self, obj):
+#         return [
+#             (Allow, 'g:admin', ALL_PERMISSIONS),
+#             (Allow, Everyone, ['index', 'show', 'collection_options',
+#                                'item_options']),
+#         ]
+
+class GuestACL(ContainerACL):
     """ Guest level ACL.
 
     Gives read permissions to everyone.
     """
-    def __init__(self, request):
-        super(GuestACL, self).__init__(request)
-        self.acl = (
-            Allow, Everyone, ['index', 'show', 'collection_options',
-                              'item_options'])
+    __acl__ = (
+        (Allow, 'g:admin', ALL_PERMISSIONS),
+        (Allow, Everyone, ('view', 'options')),
+    )
 
-    def context_acl(self, obj):
-        return [
-            (Allow, 'g:admin', ALL_PERMISSIONS),
-            (Allow, Everyone, ['index', 'show', 'collection_options',
-                               'item_options']),
-        ]
+# class AuthenticatedReadACL(BaseACL):
+#     """ Authenticated users' ACL.
 
+#     Gives read access to all Authenticated users.
+#     Gives delete, create, update access to admin only.
+#     """
+#     def __init__(self, request):
+#         super(AuthenticatedReadACL, self).__init__(request)
+#         self.acl = (Allow, Authenticated, ['index', 'collection_options'])
 
-class AuthenticatedReadACL(BaseACL):
+#     def context_acl(self, obj):
+#         return [
+#             (Allow, 'g:admin', ALL_PERMISSIONS),
+#             (Allow, Authenticated, ['show', 'item_options']),
+#         ]
+
+class AuthenticatedReadACL(ContainerACL):
     """ Authenticated users' ACL.
 
     Gives read access to all Authenticated users.
     Gives delete, create, update access to admin only.
     """
-    def __init__(self, request):
-        super(AuthenticatedReadACL, self).__init__(request)
-        self.acl = (Allow, Authenticated, ['index', 'collection_options'])
+    __acl__ = (
+        (Allow, 'g:admin', ALL_PERMISSIONS),
+        (Allow, Authenticated, ('view', 'options')),
+    )
 
-    def context_acl(self, obj):
-        return [
-            (Allow, 'g:admin', ALL_PERMISSIONS),
-            (Allow, Authenticated, ['show', 'item_options']),
-        ]
+# class AuthenticationACL(BaseACL):
+#     """ Special ACL factory to be used with authentication views
+#     (login, logout, register, etc.)
 
+#     Allows 'create', 'show' and option methods to everyone.
+#     """
+#     def __init__(self, request):
+#         super(AuthenticationACL, self).__init__(request)
+#         self.acl = (Allow, Everyone, [
+#             'create', 'show', 'collection_options', 'item_options'])
 
-class AuthenticationACL(BaseACL):
+#     def context_acl(self, obj):
+#         return [
+#             (Allow, 'g:admin', ALL_PERMISSIONS),
+#             (Allow, Everyone, [
+#                 'create', 'show', 'collection_options', 'item_options']),
+#         ]
+
+class AuthenticationACL(ContainerACL):
     """ Special ACL factory to be used with authentication views
     (login, logout, register, etc.)
 
     Allows 'create', 'show' and option methods to everyone.
     """
-    def __init__(self, request):
-        super(AuthenticationACL, self).__init__(request)
-        self.acl = (Allow, Everyone, [
-            'create', 'show', 'collection_options', 'item_options'])
 
-    def context_acl(self, obj):
-        return [
-            (Allow, 'g:admin', ALL_PERMISSIONS),
-            (Allow, Everyone, [
-                'create', 'show', 'collection_options', 'item_options']),
-        ]
+    __acl__ = (
+        (Allow, 'g:admin', ALL_PERMISSIONS),
+        (Allow, Everyone, ('create', 'view', 'options')),
+    )

--- a/nefertari/acl.py
+++ b/nefertari/acl.py
@@ -6,10 +6,10 @@ from pyramid.security import(
     )
 
 
-
 class Contained(object):
-    """
-    Contained resource, which can inherit its acl from its parent.
+    """Contained base class resource
+
+    Can inherit its acl from its parent.
     """
 
     def __init__(self, request, name='', parent=None):
@@ -19,8 +19,7 @@ class Contained(object):
 
 
 class ItemACL(Contained):
-    """
-    Collection item Resource.
+    """Collection item Resource.
 
     Override ``db_class`` to specify a db class. Only necessary if you need
      to consult the db object to deterimine a custom acl.
@@ -40,23 +39,19 @@ class ItemACL(Contained):
             self.__acl__ = acl
 
     def custom_acl(self):
-        """
-        Returns a custom __acl__ for this instance. Returns None if this
+        """Returns a custom __acl__ for this instance. Returns None if this
         instance doesn't need a custom acl.
         """
         return None
 
     def db_key(self, key):
-        """
-        Override this method to transform the db key, e.g. to support
+        """Override this method to transform the db key, e.g. to support
         ``self`` as a key on user collections.
         """
         return key
 
     def db_object(self):
-        """
-        Get db object corresponding to this resource
-        """
+        """Get db object corresponding to this resource"""
         if self.db_class == None:
             raise Exception('No db class is defined')
         pk_field = self.db_class.pk_field()
@@ -68,8 +63,7 @@ class ItemACL(Contained):
 
 
 class ContainerACL(Contained):
-    """
-    Collection resource.
+    """Collection resource.
 
     Define a ``__acl__`` attribute on this class to define the container's
     permissions, and default child permissions. Inherits its acl from the
@@ -84,133 +78,35 @@ class ContainerACL(Contained):
     def __getitem__(self, key):
         return self.child_class(self.request, key, self)
 
-
-# class SelfParamMixin(object):
-#     """ ACL mixin that implements method to translate input key value
-#     to a user ID field, when key value equals :param_value:
-
-#     Value is only converted if user is logged in and :request.user:
-#     is an instance of :__context_class__:, thus for routes that display
-#     auth users.
-#     """
-#     param_value = 'self'
-
-#     def resolve_self_key(self, key):
-#         if key != self.param_value:
-#             return key
-#         user = getattr(self.request, 'user', None)
-#         if not user or not self.__context_class__:
-#             return key
-#         if not isinstance(user, self.__context_class__):
-#             return key
-#         obj_id = getattr(user, user.pk_field()) or key
-#         return obj_id
-
 def authenticated_userid(request):
-    """
-    Helper function that can be used in ``db_key`` to support `self`
+    """Helper function that can be used in ``db_key`` to support `self`
     as a collection key.
     """
     user = request.user
     key = user.pk_field()
     return getattr(user, key)
 
-# class BaseACL(SelfParamMixin):
-#     """ Base ACL class.
 
-#     Grants:
-#         * all collection and item access to admins.
-#     """
-#     __context_class__ = None
-
-#     def __init__(self, request):
-#         self.__acl__ = [(Allow, 'g:admin', ALL_PERMISSIONS)]
-#         self.__context_acl__ = [(Allow, 'g:admin', ALL_PERMISSIONS)]
-#         self.request = request
-
-#     @property
-#     def acl(self):
-#         return self.__acl__
-
-#     @acl.setter
-#     def acl(self, val):
-#         assert(isinstance(val, tuple))
-#         self.__acl__.append(val)
-
-#     def context_acl(self, obj):
-#         return self.__context_acl__
-
-#     def __getitem__(self, key):
-#         assert(self.__context_class__)
-#         key = self.resolve_self_key(key)
-
-#         pk_field = self.__context_class__.pk_field()
-#         obj = self.__context_class__.get(
-#             __raise=True, **{pk_field: key})
-#         obj.__acl__ = self.context_acl(obj)
-#         obj.__parent__ = self
-#         obj.__name__ = key
-#         return obj
-
-
-# class RootACL(object):
-#     __name__ = ''
-#     __parent__ = None
-#     __acl__ = (
-#         (Allow, 'g:admin', ALL_PERMISSIONS),
-#     )
-
-#     def __init__(self, request):
-#         self.request = request
-
+# Example ACL classes
+#
 
 class RootACL(Contained):
     __acl__ = (
         (Allow, 'g:admin', ALL_PERMISSIONS),
     )
 
-# class AdminACL(BaseACL):
-#     """ Admin level ACL. Gives all access to all actions.
-
-#     May be used as a default factory for root resource.
-#     """
-#     def __getitem__(self, key):
-#         return 1
-
 class AdminACL(ContainerACL):
-    """ Admin level ACL. Gives all access to all actions to admin.
+    """Admin level ACL. Gives all access to all actions to admin.
 
     May be used as a default factory for root resource.
     """
-
-    # XXX not really sure what the __getitem__ -> 1 business is about,
-    # need to clarify the purpose of this class
-
     __acl__ = (
         (Allow, 'g:admin', ALL_PERMISSIONS),
     )
 
 
-# class GuestACL(BaseACL):
-#     """ Guest level ACL.
-
-#     Gives read permissions to everyone.
-#     """
-#     def __init__(self, request):
-#         super(GuestACL, self).__init__(request)
-#         self.acl = (
-#             Allow, Everyone, ['index', 'show', 'collection_options',
-#                               'item_options'])
-
-#     def context_acl(self, obj):
-#         return [
-#             (Allow, 'g:admin', ALL_PERMISSIONS),
-#             (Allow, Everyone, ['index', 'show', 'collection_options',
-#                                'item_options']),
-#         ]
-
 class GuestACL(ContainerACL):
-    """ Guest level ACL.
+    """Guest level ACL.
 
     Gives read permissions to everyone.
     """
@@ -219,21 +115,6 @@ class GuestACL(ContainerACL):
         (Allow, Everyone, ('view', 'options')),
     )
 
-# class AuthenticatedReadACL(BaseACL):
-#     """ Authenticated users' ACL.
-
-#     Gives read access to all Authenticated users.
-#     Gives delete, create, update access to admin only.
-#     """
-#     def __init__(self, request):
-#         super(AuthenticatedReadACL, self).__init__(request)
-#         self.acl = (Allow, Authenticated, ['index', 'collection_options'])
-
-#     def context_acl(self, obj):
-#         return [
-#             (Allow, 'g:admin', ALL_PERMISSIONS),
-#             (Allow, Authenticated, ['show', 'item_options']),
-#         ]
 
 class AuthenticatedReadACL(ContainerACL):
     """ Authenticated users' ACL.
@@ -246,29 +127,12 @@ class AuthenticatedReadACL(ContainerACL):
         (Allow, Authenticated, ('view', 'options')),
     )
 
-# class AuthenticationACL(BaseACL):
-#     """ Special ACL factory to be used with authentication views
-#     (login, logout, register, etc.)
-
-#     Allows 'create', 'show' and option methods to everyone.
-#     """
-#     def __init__(self, request):
-#         super(AuthenticationACL, self).__init__(request)
-#         self.acl = (Allow, Everyone, [
-#             'create', 'show', 'collection_options', 'item_options'])
-
-#     def context_acl(self, obj):
-#         return [
-#             (Allow, 'g:admin', ALL_PERMISSIONS),
-#             (Allow, Everyone, [
-#                 'create', 'show', 'collection_options', 'item_options']),
-#         ]
 
 class AuthenticationACL(ContainerACL):
     """ Special ACL factory to be used with authentication views
     (login, logout, register, etc.)
 
-    Allows 'create', 'show' and option methods to everyone.
+    Allows create, view and option methods to everyone.
     """
 
     __acl__ = (

--- a/nefertari/polymorphic.py
+++ b/nefertari/polymorphic.py
@@ -30,7 +30,7 @@ endpoint supports: query, search, filter, sort, aggregation, etc.
 from pyramid.security import DENY_ALL, Allow, ALL_PERMISSIONS
 
 from nefertari.view import BaseView
-from nefertari.acl import ContainerACL
+from nefertari.acl import CollectionACL
 from nefertari.utils import dictset
 
 
@@ -75,7 +75,7 @@ class PolymorphicHelperMixin(object):
         return set(resources)
 
 
-class PolymorphicACL(PolymorphicHelperMixin, ContainerACL):
+class PolymorphicACL(PolymorphicHelperMixin, CollectionACL):
     """ ACL used by PolymorphicESView.
 
     Generates ACEs checking whether current request user has 'index'

--- a/nefertari/polymorphic.py
+++ b/nefertari/polymorphic.py
@@ -29,10 +29,10 @@ endpoint would be available at '/users,stories' and '/stories,users'.
 Polymorphic endpoints support all the read functionality regular ES
 endpoint supports: query, search, filter, sort, aggregation, etc.
 """
-from pyramid.security import DENY_ALL, Allow
+from pyramid.security import DENY_ALL, Allow, ALL_PERMISSIONS
 
 from nefertari.view import BaseView
-from nefertari.acl import BaseACL
+from nefertari.acl import ContainerACL
 from nefertari.utils import dictset
 from nefertari import wrappers
 
@@ -80,7 +80,7 @@ class PolymorphicHelperMixin(object):
         return set(resources)
 
 
-class PolymorphicACL(PolymorphicHelperMixin, BaseACL):
+class PolymorphicACL(PolymorphicHelperMixin, ContainerACL):
     """ ACL used by PolymorphicESView.
 
     Generates ACEs checking whether current request user has 'index'
@@ -123,14 +123,15 @@ class PolymorphicACL(PolymorphicHelperMixin, BaseACL):
         DENY_ALL is added to ACL to make sure no access rules are
         inherited.
         """
-        self.__acl__ = []
+        acl = [(Allow, 'g:admin', ALL_PERMISSIONS)]
         collections = self.get_collections()
         resources = self.get_resources(collections)
         aces = self._get_least_permissions_aces(resources)
         if aces is not None:
             for ace in aces:
-                self.acl = ace
-        self.acl = DENY_ALL
+                acl.append(ace)
+        acl.append(DENY_ALL)
+        self.__acl__ = tuple(acl)
 
 
 class PolymorphicESView(PolymorphicHelperMixin, BaseView):

--- a/nefertari/resource.py
+++ b/nefertari/resource.py
@@ -7,6 +7,18 @@ log = logging.getLogger(__name__)
 ACTIONS = ['index', 'show', 'create', 'update',
            'delete', 'update_many', 'delete_many',
            'replace']
+PERMISSIONS = {
+    'index': 'view',
+    'show': 'view',
+    'create': 'create',
+    'update': 'update',
+    'update_many': 'update',
+    'delete': 'delete',
+    'delete_many': 'delete',
+    'replace': 'update',
+    'collection_options': 'options',
+    'item_options': 'options',
+    }
 DEFAULT_ID_NAME = 'id'
 
 
@@ -103,9 +115,13 @@ def add_resource_routes(config, view, member_name, collection_name, **kwargs):
 
         action_route[action] = route_name
 
+        if _auth:
+            permission = PERMISSIONS[action]
+        else:
+            permission = None
         config.add_view(view=view, attr=action, route_name=route_name,
                         request_method=request_method,
-                        permission=action if _auth else None,
+                        permission=permission,
                         **kwargs)
         config.commit()
 

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -92,6 +92,7 @@ class TestACLsUnit(object):
 
     def test_item_404(self):
         class NotFoundModel(DummyModel):
+            @staticmethod
             def get(id, **kw):
                 raise AttributeError()
         class DummyACL(acl.CollectionACL):

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -11,129 +11,65 @@ from pyramid.security import (
 from nefertari import acl
 
 
+class DummyModel(object):
+    @staticmethod
+    def pk_field():
+        return 'id'
+    @classmethod
+    def get(cls, id, **kw):
+        i = cls()
+        i.id = id
+        return i
+
+
 class TestACLsUnit(object):
 
-    def test_no_acl(self):
-        obj = acl.ContainerACL(request='foo')
-        assert getattr(obj, '__acl__', None) is None
+    def dummy_acl(self):
+        class DummyACL(acl.CollectionACL):
+            item_model = DummyModel
+        return DummyACL
 
-        child = acl.ContainerACL(request='foo')['name']
-        assert getattr(child, '__acl__', None) is None
-
-        obj = acl.ItemACL(request='foo', name='name', parent=None)
-        assert getattr(obj, '__acl__', None) is None
+    def test_default_acl(self):
+        acl = self.dummy_acl()
+        obj = acl(request='foo')
+        assert obj.__acl__ == (('Allow', 'g:admin', ALL_PERMISSIONS),)
 
     def test_inherit_acl(self):
-        obj = acl.ContainerACL(request='foo')
-        obj.__acl__ = ((Allow, Everyone, ALL_PERMISSIONS),)
-        child = obj['name']
-        assert child.__parent__.__acl__ == obj.__acl__
+        acl = self.dummy_acl()
+        item = acl(request='foo')['name']
+        assert getattr(item, '__acl__', None) == None
 
-    def test_child_class(self):
-        class MyItem(acl.ItemACL):
-            __acl__ = ((Allow, Everyone, ALL_PERMISSIONS),)
-        class MyContainer(acl.ContainerACL):
-            __acl__ = ((Deny, Everyone, ALL_PERMISSIONS),)
-            child_class = MyItem
-
-        obj = MyContainer(request='foo')
-        child = obj['name']
-        assert child.__acl__ == ((Allow, Everyone, ALL_PERMISSIONS),)
-        assert child.__parent__.__acl__ != child.__acl__
+    def test_item(self):
+        acl = self.dummy_acl()
+        item = acl(request='foo')['item-id']
+        assert item.id == 'item-id'
+        assert isinstance(item, acl.item_model)
 
     def test_custom_acl(self):
-        class MyItem(acl.ItemACL):
-            def custom_acl(self):
-                return ((Allow, self.__name__, 'update'),)
-        class MyContainer(acl.ContainerACL):
-            child_class = MyItem
+        class DummyACL(acl.CollectionACL):
+            item_model = DummyModel
+            def item_acl(self, item):
+                return (
+                    (Allow, item.id, 'update'),
+                    )
+        r = DummyACL(request='foo')
+        item = r['item-id']
+        assert item.__acl__ == ((Allow, 'item-id', 'update'),)
 
-        obj = MyContainer(request='foo')
-        child = obj['name']
-        assert child.__acl__ == ((Allow, 'name', 'update'),)
+    def test_db_id(self):
+        class DummyACL(acl.CollectionACL):
+            item_model = DummyModel
+            def item_db_id(self, key):
+                if key == 'self':
+                    return 42
+                return key
+        r = DummyACL(request='foo')
+        item = r['item-id']
+        assert item.id == 'item-id'
+        item = r['self']
+        assert item.id == 42
 
-    def test_rootacl(self):
-        acl_obj = acl.RootACL(request='foo')
-        assert acl_obj.__acl__ == ((Allow, 'g:admin', ALL_PERMISSIONS),)
-        assert acl_obj.request == 'foo'
-
-    def test_adminacl(self):
-        acl_obj = acl.AdminACL(request='foo')
-        #assert isinstance(acl_obj, acl.BaseACL)
-        #assert acl_obj['foo'] == 1
-        #assert acl_obj['qweoo'] == 1
-
-    def test_guestacl_acl(self):
-        acl_obj = acl.GuestACL(request='foo')
-        assert acl_obj.__acl__ == (
-            (Allow, 'g:admin', ALL_PERMISSIONS),
-            (Allow, Everyone, ('view', 'options'))
-        )
-
-    def test_guestacl_context_acl(self):
-        acl_obj = acl.GuestACL(request='foo')
-        child = acl_obj['name']
-        assert getattr(child, '__acl__', None) is None
-        assert child.__parent__.__acl__ == (
-            (Allow, 'g:admin', ALL_PERMISSIONS),
-            (Allow, Everyone, ('view', 'options')),
-        )
-
-    def test_authenticatedreadacl_acl(self):
-        acl_obj = acl.AuthenticatedReadACL(request='foo')
-        assert acl_obj.__acl__ == (
-            (Allow, 'g:admin', ALL_PERMISSIONS),
-            (Allow, Authenticated, ('view', 'options'))
-        )
-
-    def test_authenticatedreadacl_context_acl(self):
-        acl_obj = acl.AuthenticatedReadACL(request='foo')
-        child =  acl_obj['asdasd']
-        assert getattr(child, '__acl__', None) is None
-        assert child.__parent__.__acl__ == (
-            (Allow, 'g:admin', ALL_PERMISSIONS),
-            (Allow, Authenticated, ('view', 'options')),
-        )
-
-
-
-class TestDBObject(object):
-
-    def test_no_db_class(self):
-        obj = acl.ItemACL(request=42, name='name', parent=None)
-        with pytest.raises(Exception) as e:
-            obj.db_object()
-        assert str(e.value) == 'No db class is defined'
-
-    def test_db_obj(self):
-        class DBClass(object):
-            @staticmethod
-            def pk_field():
-                return 'id'
-            @staticmethod
-            def get(id, **kw):
-                return id
-        class MyItem(acl.ItemACL):
-            db_class = DBClass
-        obj = MyItem(request=42, name='name', parent=None)
-        assert obj.db_object() == 'name'
-
-    def test_db_key(self):
-        class DBClass(object):
-            @staticmethod
-            def pk_field():
-                return 'id'
-            @staticmethod
-            def get(id, **kw):
-                return id
-        class MyItem(acl.ItemACL):
-            db_class = DBClass
-            def db_key(self, key):
-                return key.capitalize()
-        obj = MyItem(request=42, name='name', parent=None)
-        assert obj.db_object() == 'Name'
-
-    def test_self_db_key(self):
+    def test_self_db_id(self):
         from nefertari.acl import authenticated_userid
         class DBClass(object):
             @staticmethod
@@ -142,12 +78,42 @@ class TestDBObject(object):
             @staticmethod
             def get(id, **kw):
                 return id
-        class MyItem(acl.ItemACL):
-            db_class = DBClass
-            def db_key(self, key):
-                return authenticated_userid(self.request)
+        class UserACL(acl.CollectionACL):
+            item_model = DummyModel
+            def item_db_id(self, key):
+                if self.request.user is not None and key == 'self':
+                    return authenticated_userid(self.request)
+                return key
         user = Mock(username='user12')
         user.pk_field.return_value = 'username'
         req = Mock(user=user)
-        obj = MyItem(request=req, name='self', parent=None)
-        assert obj.db_object() == 'user12'
+        obj = UserACL(request=req)['self']
+        assert obj.id == 'user12'
+
+    def test_item_404(self):
+        class NotFoundModel(DummyModel):
+            def get(id, **kw):
+                raise AttributeError()
+        class DummyACL(acl.CollectionACL):
+            item_model = NotFoundModel
+        with pytest.raises(KeyError):
+            DummyACL(request='foo')['item-id']
+
+    def test_rootacl(self):
+        acl_obj = acl.RootACL(request='foo')
+        assert acl_obj.__acl__ == ((Allow, 'g:admin', ALL_PERMISSIONS),)
+        assert acl_obj.request == 'foo'
+
+    def test_guestacl_acl(self):
+        acl_obj = acl.GuestACL(request='foo')
+        assert acl_obj.__acl__ == (
+            (Allow, 'g:admin', ALL_PERMISSIONS),
+            (Allow, Everyone, ('view', 'options'))
+        )
+
+    def test_authenticatedreadacl_acl(self):
+        acl_obj = acl.AuthenticatedReadACL(request='foo')
+        assert acl_obj.__acl__ == (
+            (Allow, 'g:admin', ALL_PERMISSIONS),
+            (Allow, Authenticated, ('view', 'options'))
+        )

--- a/tests/test_polymorphic.py
+++ b/tests/test_polymorphic.py
@@ -80,8 +80,8 @@ class TestPolymorphicACL(object):
         mock_res.return_value = ['foo', 'bar']
         mock_aces.return_value = None
         acl = polymorphic.PolymorphicACL(None)
-        assert len(acl.acl) == 1
-        assert [DENY_ALL] == acl.acl
+        assert len(acl.__acl__) == 2
+        assert DENY_ALL == acl.__acl__[-1]
         mock_coll.assert_called_once_with()
         mock_res.assert_called_once_with(['stories', 'users'])
         mock_aces.assert_called_once_with(['foo', 'bar'])
@@ -95,9 +95,9 @@ class TestPolymorphicACL(object):
         aces = [(Allow, 'foobar', 'dostuff')]
         mock_aces.return_value = aces
         acl = polymorphic.PolymorphicACL(None)
-        assert len(acl.acl) == 2
-        assert DENY_ALL == acl.acl[-1]
-        assert aces[0] in acl.acl
+        assert len(acl.__acl__) == 3
+        assert DENY_ALL == acl.__acl__[-1]
+        assert aces[0] in acl.__acl__
         assert mock_coll.call_count == 1
         assert mock_res.call_count == 1
         assert mock_aces.call_count == 1


### PR DESCRIPTION
Refactoring of nerfertari.acl

-  simplified base collection resource class.
- no more magic `self` item
- simplified permissions for collection and item methods - see nefertari.resource.PERMISSIONS

Hopefully these changes make it easier to create a separate package for acls in db.

These changes also require changes to nefertari-example and ramses. See those packages for related PRs. 